### PR TITLE
fix: extra characters in path that are not allowed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           node dist/index.js list --available
           node dist/index.js doctor
 
-      - name: Run tests
+      - name: Run tests (excluding Windows-specific tests)
         run: pnpm -r run test
         continue-on-error: true  # Allow CI to pass despite test failures (for now)
 

--- a/.github/workflows/windows-backup-test.yml
+++ b/.github/workflows/windows-backup-test.yml
@@ -1,0 +1,119 @@
+name: Windows Backup Path Test
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'packages/cli/src/core/config-engine.ts'
+      - 'packages/cli/tests/config-engine.test.ts'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'packages/cli/src/core/config-engine.ts'
+      - 'packages/cli/tests/config-engine.test.ts'
+  workflow_dispatch:
+
+jobs:
+  windows-backup-test:
+    runs-on: windows-latest
+    
+    strategy:
+      matrix:
+        node-version: [18]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: latest
+    
+    - name: Install dependencies (root)
+      run: pnpm install --frozen-lockfile
+    
+    - name: Build shared package
+      run: pnpm run build
+      working-directory: ./packages/shared
+    
+    - name: Build CLI package
+      run: pnpm run build
+      working-directory: ./packages/cli
+    
+    - name: Run Windows backup path tests only
+      shell: powershell
+      run: |
+        # Run Windows-specific tests using the dedicated Jest config
+        pnpm run test:windows
+      working-directory: ./packages/cli
+      env:
+        INCLUDE_WINDOWS_TESTS: true
+      
+    - name: Test actual install command on Windows
+      shell: powershell
+      run: |
+        # Test the actual mcp-installer install command to verify backup paths work
+        Write-Host "Testing mcp-installer install with Windows paths..."
+        
+        # Create a mock Claude config to test backup creation
+        $claudeDir = "$env:USERPROFILE\.claude"
+        $configPath = "$claudeDir\config.json"
+        New-Item -ItemType Directory -Force -Path $claudeDir
+        '{"mcpServers": {}}' | Out-File -FilePath $configPath -Encoding UTF8
+        Write-Host "Created test config at: $configPath"
+        
+        # Try to run install command (may fail due to missing dependencies, but should create backup)
+        try {
+          Write-Host "Running: node dist/index.js install memory --clients=claude-code"
+          node dist/index.js install memory --clients=claude-code
+          Write-Host "Install command completed successfully"
+        } catch {
+          Write-Host "Install command failed (expected due to missing dependencies), but backup should still be created"
+        }
+        
+        # Check if backup was created with sanitized filename
+        $backupDir = "$env:USERPROFILE\.mcp-installer\backups"
+        Write-Host "Checking backup directory: $backupDir"
+        
+        if (Test-Path $backupDir) {
+          Write-Host "Backup directory exists"
+          $backupFiles = Get-ChildItem -Path $backupDir -Filter "*.backup" -ErrorAction SilentlyContinue
+          
+          if ($backupFiles -and $backupFiles.Count -gt 0) {
+            Write-Host "✅ Backup created successfully:"
+            $backupFiles | ForEach-Object { Write-Host "  - $($_.Name)" }
+            
+            # Verify no invalid characters in backup filename
+            $hasInvalidChars = $false
+            $backupFiles | ForEach-Object {
+              if ($_.Name -match '[<>:"|?*\\]') {
+                Write-Host "❌ Backup filename contains invalid characters: $($_.Name)"
+                $hasInvalidChars = $true
+              }
+            }
+            
+            if (-not $hasInvalidChars) {
+              Write-Host "✅ All backup filenames are valid for Windows"
+            } else {
+              exit 1
+            }
+          } else {
+            Write-Host "⚠️ No backup files found in directory"
+            # List all files in backup directory for debugging
+            $allFiles = Get-ChildItem -Path $backupDir -ErrorAction SilentlyContinue
+            if ($allFiles) {
+              Write-Host "Files in backup directory:"
+              $allFiles | ForEach-Object { Write-Host "  - $($_.Name)" }
+            }
+          }
+        } else {
+          Write-Host "⚠️ Backup directory does not exist: $backupDir"
+        }
+      working-directory: ./packages/cli
+      continue-on-error: true
+    

--- a/packages/cli/jest-windows.config.cjs
+++ b/packages/cli/jest-windows.config.cjs
@@ -9,9 +9,8 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   roots: ['<rootDir>/src', '<rootDir>/tests'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  // Exclude Windows-specific tests from main CI runs
-  testPathIgnorePatterns: process.env.INCLUDE_WINDOWS_TESTS ? [] : ['.*windows.*\\.test\\.ts$'],
+  // Only run Windows-specific tests
+  testMatch: ['**/*windows*.test.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/index.ts',
@@ -22,4 +21,4 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-};
+}; 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/**/*.ts",
     "test": "jest",
+    "test:windows": "jest --config jest-windows.config.cjs",
     "test:watch": "jest --watch",
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },

--- a/packages/cli/src/core/config-engine.ts
+++ b/packages/cli/src/core/config-engine.ts
@@ -1,6 +1,6 @@
 import fsExtra from 'fs-extra';
 const { readFile, writeFile, ensureDir, copy } = fsExtra;
-import { dirname, join } from 'path';
+import { dirname, join, basename } from 'path';
 import { existsSync } from 'fs';
 import {
   ClientType,
@@ -243,7 +243,8 @@ export class ConfigEngine {
     }
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const backupFileName = `${basename(configPath)}.${timestamp}.backup`;
+    const sanitizedConfigPath = configPath.replace(/[:/\\]/g, '_');
+    const backupFileName = `${basename(sanitizedConfigPath)}.${timestamp}.backup`;
     const backupPath = join(ConfigEngine.BACKUP_DIR, backupFileName);
 
     await ensureDir(ConfigEngine.BACKUP_DIR);
@@ -297,8 +298,4 @@ export class ConfigEngine {
     // This would need more sophisticated logic to determine the original path
     throw new Error('Cannot infer original path from backup. Please specify target path.');
   }
-}
-
-function basename(path: string): string {
-  return path.split('/').pop() || path.split('\\').pop() || path;
 }

--- a/packages/cli/tests/config-engine-windows.test.ts
+++ b/packages/cli/tests/config-engine-windows.test.ts
@@ -1,0 +1,53 @@
+import { vol } from 'memfs';
+import { ConfigEngine } from '../src/core/config-engine';
+
+describe('ConfigEngine - Windows Specific Tests', () => {
+  let configEngine: ConfigEngine;
+
+  beforeEach(() => {
+    vol.reset();
+    configEngine = new ConfigEngine();
+  });
+
+  describe('createBackup - Windows paths', () => {
+    it('should handle Windows paths with colons and backslashes', async () => {
+      const windowsConfigPath = 'C:\\Users\\myUser\\.claude\\config.json';
+      const testConfig = {
+        mcpServers: {
+          'playwright': {
+            command: 'npx',
+            args: ['@playwright/mcp@latest']
+          }
+        }
+      };
+
+      vol.fromJSON({
+        [windowsConfigPath]: JSON.stringify(testConfig)
+      });
+
+      const backup = await configEngine.createBackup(windowsConfigPath);
+
+      expect(backup.backupPath).toBeDefined();
+
+      // Extract just the backup filename from the full path
+      const backupFileName = backup.backupPath.split(/[/\\]/).pop();
+      expect(backupFileName).toBeDefined();
+
+      // The backup filename should not contain invalid Windows filename characters
+      expect(backupFileName).not.toMatch(/[<>:"|?*]/);
+      expect(backupFileName).toContain('C_');
+      expect(backupFileName).toContain('Users_myUser');
+      expect(backupFileName).toContain('.backup');
+
+      expect(backup.configPath).toBe(windowsConfigPath);
+      expect(backup.timestamp).toBeDefined();
+    });
+
+    it('should throw error when Windows config file does not exist', async () => {
+      const nonExistentPath = 'C:\\NonExistent\\config.json';
+
+      await expect(configEngine.createBackup(nonExistentPath))
+        .rejects.toThrow('Config file does not exist');
+    });
+  });
+}); 

--- a/packages/cli/tests/config-engine.test.ts
+++ b/packages/cli/tests/config-engine.test.ts
@@ -228,6 +228,38 @@ describe('ConfigEngine', () => {
     });
   });
 
+  describe('createBackup', () => {
+    it('should handle Unix paths normally', async () => {
+      const unixConfigPath = '/Users/test/.cursor/mcp.json';
+      const testConfig = {
+        mcpServers: {
+          'filesystem': {
+            command: 'npx',
+            args: ['@modelcontextprotocol/server-filesystem']
+          }
+        }
+      };
+
+      vol.fromJSON({
+        [unixConfigPath]: JSON.stringify(testConfig)
+      });
+
+      const backup = await configEngine.createBackup(unixConfigPath);
+      
+      expect(backup.backupPath).toBeDefined();
+      expect(backup.backupPath).toContain('_Users_test_');
+      expect(backup.configPath).toBe(unixConfigPath);
+      expect(backup.timestamp).toBeDefined();
+    });
+
+    it('should throw error when config file does not exist', async () => {
+      const nonExistentPath = '/Users/nonexistent/.cursor/config.json';
+
+      await expect(configEngine.createBackup(nonExistentPath))
+        .rejects.toThrow('Config file does not exist');
+    });
+  });
+
   describe('validateConfig', () => {
     it('should validate correct config', async () => {
       const validConfig = {

--- a/packages/cli/tests/install-command.test.ts
+++ b/packages/cli/tests/install-command.test.ts
@@ -100,11 +100,11 @@ describe('installCommand', () => {
       promptAndInstallMissingCommands: jest.fn(),
     } as any;
 
-    (ServerRegistry as jest.Mock).mockImplementation(() => mockServerRegistry);
-    (ClientManager as jest.Mock).mockImplementation(() => mockClientManager);
-    (ConfigEngine as jest.Mock).mockImplementation(() => mockConfigEngine);
-    (ParameterHandler as jest.Mock).mockImplementation(() => mockParameterHandler);
-    (CommandValidator as jest.Mock).mockImplementation(() => mockCommandValidator);
+    (ServerRegistry as jest.MockedClass<typeof ServerRegistry>).mockImplementation(() => mockServerRegistry);
+    (ClientManager as jest.MockedClass<typeof ClientManager>).mockImplementation(() => mockClientManager);
+    (ConfigEngine as jest.MockedClass<typeof ConfigEngine>).mockImplementation(() => mockConfigEngine);
+    (ParameterHandler as jest.MockedClass<typeof ParameterHandler>).mockImplementation(() => mockParameterHandler);
+    (CommandValidator as jest.MockedClass<typeof CommandValidator>).mockImplementation(() => mockCommandValidator);
 
     // Setup console and process mocks
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -120,9 +120,9 @@ describe('installCommand', () => {
     id: 'test-server',
     name: 'Test Server',
     description: 'A test server',
-    category: 'utility',
-    type: 'stdio',
-    difficulty: 'simple',
+    category: 'utility' as const,
+    type: 'stdio' as const,
+    difficulty: 'simple' as const,
     requiresAuth: false,
     installation: {
       command: 'npx',
@@ -133,14 +133,14 @@ describe('installCommand', () => {
 
   const mockClients = [
     {
-      type: 'claude-desktop',
+      type: 'claude-desktop' as const,
       isInstalled: true,
       configPath: '/test/claude.json',
       name: 'Claude Desktop',
       configExists: true,
     },
     {
-      type: 'cursor',
+      type: 'cursor' as const,
       isInstalled: true,
       configPath: '/test/cursor.json',
       name: 'Cursor',
@@ -474,7 +474,7 @@ describe('installCommand', () => {
         args: ['test-package', '--param1', 'value1'],
         env: undefined,
       });
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ confirm: true });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ confirm: true });
 
       await installCommand('test-server', { clients: 'all' });
 
@@ -496,7 +496,7 @@ describe('installCommand', () => {
       mockParameterHandler.hasParameters.mockReturnValue(true);
       mockParameterHandler.promptForParameters.mockResolvedValue({});
       mockParameterHandler.previewCommand.mockReturnValue('npx test-package');
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ confirm: false });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ confirm: false });
 
       await installCommand('test-server', { clients: 'all' });
 
@@ -542,7 +542,20 @@ describe('installCommand', () => {
     it('should handle server not found', async () => {
       mockServerRegistry.getServer.mockResolvedValue(null);
       mockServerRegistry.getAllServers.mockResolvedValue([
-        { id: 'other-server', description: 'Other server' },
+        { 
+          id: 'other-server', 
+          name: 'Other Server',
+          description: 'Other server',
+          category: 'utility' as const,
+          type: 'stdio' as const,
+          difficulty: 'simple' as const,
+          requiresAuth: false,
+          installation: {
+            command: 'npx',
+            args: ['other-package'],
+          },
+          documentation: 'https://example.com',
+        },
       ]);
 
       await installCommand('nonexistent-server', { clients: 'all' });
@@ -778,7 +791,7 @@ describe('installCommand', () => {
         failedCommands: [],
         userDeclined: false,
       });
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ proceed: true });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ proceed: true });
 
       await installCommand('test-server', { clients: 'all' });
 

--- a/packages/cli/tests/setup.ts
+++ b/packages/cli/tests/setup.ts
@@ -57,6 +57,9 @@ jest.mock('fs-extra', () => {
       return new Promise((resolve, reject) => {
         try {
           const content = memfs.vol.readFileSync(src);
+          // Ensure destination directory exists
+          const destDir = require('path').dirname(dest);
+          memfs.vol.mkdirSync(destDir, { recursive: true });
           memfs.vol.writeFileSync(dest, content);
           resolve(undefined);
         } catch (error) {

--- a/packages/cli/tests/uninstall-command.test.ts
+++ b/packages/cli/tests/uninstall-command.test.ts
@@ -63,14 +63,14 @@ describe('uninstallCommand', () => {
       isClientSupported: jest.fn(),
       getSupportedClients: jest.fn(),
     } as any;
-    (ClientManager as jest.Mock).mockImplementation(() => mockClientManager);
+    (ClientManager as jest.MockedClass<typeof ClientManager>).mockImplementation(() => mockClientManager);
 
     // Setup ConfigEngine mock
     mockConfigEngine = {
       listInstalledServers: jest.fn(),
       uninstallServer: jest.fn(),
     } as any;
-    (ConfigEngine as jest.Mock).mockImplementation(() => mockConfigEngine);
+    (ConfigEngine as jest.MockedClass<typeof ConfigEngine>).mockImplementation(() => mockConfigEngine);
 
     // Setup console and process mocks
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -120,7 +120,7 @@ describe('uninstallCommand', () => {
       });
 
       mockConfigEngine.uninstallServer.mockResolvedValue();
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ proceed: true });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ proceed: true });
     });
 
     it('should successfully uninstall from all clients', async () => {
@@ -208,7 +208,7 @@ describe('uninstallCommand', () => {
     });
 
     it('should handle user cancellation', async () => {
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ proceed: false });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ proceed: false });
 
       await uninstallCommand('test-server', { clients: 'all' });
 
@@ -295,7 +295,7 @@ describe('uninstallCommand', () => {
         .mockResolvedValueOnce() // Success for cursor
         .mockRejectedValueOnce(new Error('Uninstall failed')); // Error for gemini
 
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ proceed: true });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ proceed: true });
 
       await uninstallCommand('test-server', { clients: 'all' });
 
@@ -330,7 +330,7 @@ describe('uninstallCommand', () => {
     });
 
     it('should show correct confirmation prompt', async () => {
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ proceed: true });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ proceed: true });
 
       await uninstallCommand('test-server', { clients: 'all' });
 
@@ -345,7 +345,7 @@ describe('uninstallCommand', () => {
     });
 
     it('should display affected clients before confirmation', async () => {
-      (inquirer.prompt as jest.Mock).mockResolvedValue({ proceed: true });
+      (inquirer.prompt as jest.MockedFunction<typeof inquirer.prompt>).mockResolvedValue({ proceed: true });
 
       await uninstallCommand('test-server', { clients: 'all' });
 


### PR DESCRIPTION
Fixes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new test cases to verify backup filename sanitization for both Windows and Unix-style paths, and to ensure proper error handling when backing up non-existent config files.
  * Added Windows-specific tests for backup creation handling Windows-style paths.
  * Improved the test setup to handle directory creation in the mocked filesystem environment.
  * Enhanced type safety and completeness of mocks in install and uninstall command tests.

* **Chores**
  * Introduced a new GitHub Actions workflow to automatically test Windows backup path handling and filename sanitization.
  * Added a Windows-specific Jest configuration and npm script to run Windows-only tests.
  * Updated TypeScript configuration to include test files in compilation.

* **Bug Fixes**
  * Updated backup filename generation to sanitize Windows paths, ensuring backup files do not contain invalid characters.

* **Documentation**
  * Clarified test step naming in CI workflow for better distinction of Windows-specific tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->